### PR TITLE
Add bilingual language support

### DIFF
--- a/client/src/components/about-section.tsx
+++ b/client/src/components/about-section.tsx
@@ -1,77 +1,68 @@
 import { CheckCircle, Eye, Heart } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
+
+const icons = [CheckCircle, Eye, Heart];
+const iconBackgrounds = ["bg-primary", "bg-accent", "bg-secondary"] as const;
+const iconColors = ["text-primary-foreground", "text-accent-foreground", "text-primary"] as const;
 
 export default function AboutSection() {
+  const { language } = useLanguage();
+  const content = translations.about[language];
+
   return (
     <section id="about" className="section-padding bg-background">
       <div className="container mx-auto px-6">
         <div className="grid md:grid-cols-2 gap-12 items-center mb-16">
           <div>
             <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-6">
-              Бидний тухай
+              {content.title}
             </h2>
             <p className="text-lg text-muted-foreground mb-6">
-              1992 оноос эхтэй уламжлалт сургалтын арга зүйг дижитал шилжилттэй хослуулж, хөдөлмөрийн зах зээлд бэлэн, ёс зүйтэй, бүтээлч мэргэжилтэн бэлтгэнэ.
+              {content.description}
             </p>
             <div className="flex items-center text-primary font-semibold">
-              <span>30+ жилийн туршлага</span>
-              <span className="mx-4">•</span>
-              <span>5000+ төгсөгч</span>
+              {content.stats.map((stat, index) => (
+                <div key={stat} className="flex items-center">
+                  <span>{stat}</span>
+                  {index < content.stats.length - 1 && <span className="mx-4">•</span>}
+                </div>
+              ))}
             </div>
           </div>
           <div>
             <img
-              src="https://pixabay.com/get/g47b8881a41e33f23759fbefd12f1bde190091c32b7b2338a0a5077002520b601e31edc8e67d007e38aadac2d08bf83b82aff743531d9583325fa696e38639e7d_1280.jpg"
-              alt="Их сургуулийн кампус"
+              src="https://pixabay.com/get/g47b8881a41e33f23759fbefd12f1bde190091c32b7b2338a0a5077002520b601e31edc8e67d007e38aadc2d08bf83b82aff743531d9583325fa696e38639e7d_1280.jpg"
+              alt={content.imageAlt}
               className="rounded-xl shadow-lg w-full h-auto"
               loading="lazy"
             />
           </div>
         </div>
 
-        {/* Mission, Vision, Values Cards */}
         <div className="grid md:grid-cols-3 gap-8">
-          <Card className="card-hover">
-            <CardContent className="p-8">
-              <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center mb-4">
-                <CheckCircle className="w-6 h-6 text-primary-foreground" />
-              </div>
-              <h3 className="text-xl font-bold mb-3 text-card-foreground">
-                Эрхэм зорилго
-              </h3>
-              <p className="text-muted-foreground">
-                Чанартай боловсролоор нийгмийн хөгжилд хувь нэмэр оруулах.
-              </p>
-            </CardContent>
-          </Card>
+          {content.cards.map((card, index) => {
+            const Icon = icons[index];
+            const background = iconBackgrounds[index];
+            const iconColor = iconColors[index];
 
-          <Card className="card-hover">
-            <CardContent className="p-8">
-              <div className="w-12 h-12 bg-accent rounded-lg flex items-center justify-center mb-4">
-                <Eye className="w-6 h-6 text-accent-foreground" />
-              </div>
-              <h3 className="text-xl font-bold mb-3 text-card-foreground">
-                Алсын хараа
-              </h3>
-              <p className="text-muted-foreground">
-                Судалгаа, инновацаар тэргүүлсэн их сургууль.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="card-hover">
-            <CardContent className="p-8">
-              <div className="w-12 h-12 bg-secondary rounded-lg flex items-center justify-center mb-4">
-                <Heart className="w-6 h-6 text-primary" />
-              </div>
-              <h3 className="text-xl font-bold mb-3 text-card-foreground">
-                Үнэт зүйлс
-              </h3>
-              <p className="text-muted-foreground">
-                Оюунлаг байдал • Шударга ёс • Хамтын хөгжил.
-              </p>
-            </CardContent>
-          </Card>
+            return (
+              <Card key={card.title} className="card-hover">
+                <CardContent className="p-8">
+                  <div className={`w-12 h-12 ${background} rounded-lg flex items-center justify-center mb-4`}>
+                    {Icon && <Icon className={`w-6 h-6 ${iconColor}`} />}
+                  </div>
+                  <h3 className="text-xl font-bold mb-3 text-card-foreground">
+                    {card.title}
+                  </h3>
+                  <p className="text-muted-foreground">
+                    {card.description}
+                  </p>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/client/src/components/admissions-section.tsx
+++ b/client/src/components/admissions-section.tsx
@@ -1,49 +1,38 @@
 import { Download } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-
-const steps = [
-  {
-    step: 1,
-    title: "Бүртгүүлэх",
-    description: "Онлайн бүртгэл хийх, хувийн мэдээлэл оруулах"
-  },
-  {
-    step: 2, 
-    title: "Бичиг баримт",
-    description: "Шаардлагатай баримтуудыг бүрдүүлэх"
-  },
-  {
-    step: 3,
-    title: "Шалгалт/Ярилцлага", 
-    description: "Элсэлтийн шалгалт болон ярилцлага"
-  },
-  {
-    step: 4,
-    title: "Элсэлт баталгаажуулах",
-    description: "Элсэн орох эрхийг баталгаажуулах"
-  }
-];
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
 export default function AdmissionsSection() {
+  const { language } = useLanguage();
+  const content = translations.admissions[language];
+
   return (
     <section id="admissions" className="section-padding bg-background">
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Элсэлт
+            {content.title}
           </h2>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Элсэлтийн үйл явц, шаардлага, хугацаа
+            {content.description}
           </p>
         </div>
 
-        {/* Process Steps */}
         <div className="grid md:grid-cols-4 gap-8 mb-12">
-          {steps.map((stepInfo) => (
+          {content.steps.map((stepInfo) => (
             <div key={stepInfo.step} className="text-center">
-              <div className={`w-16 h-16 ${stepInfo.step === 4 ? 'bg-accent' : 'bg-primary'} rounded-full flex items-center justify-center mx-auto mb-4`}>
-                <span className={`text-2xl font-bold ${stepInfo.step === 4 ? 'text-accent-foreground' : 'text-primary-foreground'}`}>
+              <div
+                className={`w-16 h-16 ${
+                  stepInfo.step === 4 ? "bg-accent" : "bg-primary"
+                } rounded-full flex items-center justify-center mx-auto mb-4`}
+              >
+                <span
+                  className={`text-2xl font-bold ${
+                    stepInfo.step === 4 ? "text-accent-foreground" : "text-primary-foreground"
+                  }`}
+                >
                   {stepInfo.step}
                 </span>
               </div>
@@ -57,29 +46,28 @@ export default function AdmissionsSection() {
           ))}
         </div>
 
-        {/* Requirements */}
         <Card className="shadow-lg">
           <CardContent className="p-8">
             <h3 className="text-xl font-bold mb-4 text-card-foreground">
-              Шаардлагатай баримтууд
+              {content.requirementsTitle}
             </h3>
             <p className="text-muted-foreground mb-6">
-              Онлайн бүртгэл нээлттэй. Бүрдүүлэх материал: иргэний үнэмлэх, цээж зураг, ЭЕШ оноо/дунд сургуулийн голч дүн, цахим төлбөрийн баримт.
+              {content.requirementsDescription}
             </p>
             <div className="flex flex-col sm:flex-row gap-4">
-              <Button 
+              <Button
                 className="flex items-center"
                 data-testid="button-download-guide"
               >
                 <Download className="w-5 h-5 mr-2" />
-                Элсэлтийн журам (PDF)
+                {content.downloadButton}
               </Button>
-              <Button 
+              <Button
                 variant="secondary"
                 className="bg-accent text-accent-foreground hover:bg-accent/90"
                 data-testid="button-register-online"
               >
-                Онлайн бүртгүүлэх
+                {content.registerButton}
               </Button>
             </div>
           </CardContent>

--- a/client/src/components/contact-section.tsx
+++ b/client/src/components/contact-section.tsx
@@ -8,40 +8,42 @@ import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
+
+const infoIcons = [MapPin, Phone, Mail, Clock];
 
 export default function ContactSection() {
   const [formData, setFormData] = useState({
     name: "",
-    phone: "", 
+    phone: "",
     email: "",
     message: ""
   });
   const { toast } = useToast();
+  const { language } = useLanguage();
+  const content = translations.contact[language];
 
   const contactMutation = useMutation({
     mutationFn: async (data: typeof formData) => {
-      return apiRequest("/api/contact", {
-        method: "POST",
-        body: data,
-      });
+      return apiRequest("POST", "/api/contact", data);
     },
-    onSuccess: (data) => {
+    onSuccess: () => {
       toast({
-        title: "Амжилттай",
-        description: data.message || "Таны мессеж амжилттай илгээгдлээ!",
+        title: content.toast.successTitle,
+        description: content.toast.successDescription,
       });
-      // Reset form
       setFormData({
         name: "",
         phone: "",
-        email: "", 
+        email: "",
         message: ""
       });
     },
     onError: (error: any) => {
       toast({
-        title: "Алдаа",
-        description: error.message || "Мессеж илгээхэд алдаа гарлаа",
+        title: content.toast.errorTitle,
+        description: error?.message || content.toast.submitError,
         variant: "destructive",
       });
     },
@@ -56,12 +58,11 @@ export default function ContactSection() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    
-    // Basic validation
+
     if (!formData.name || !formData.email || !formData.message) {
       toast({
-        title: "Алдаа",
-        description: "Бүх шаардлагатай талбарыг бөглөнө үү",
+        title: content.toast.errorTitle,
+        description: content.toast.requiredFields,
         variant: "destructive",
       });
       return;
@@ -69,8 +70,8 @@ export default function ContactSection() {
 
     if (!formData.email.includes('@')) {
       toast({
-        title: "Алдаа", 
-        description: "Зөв имэйл хаяг оруулна уу",
+        title: content.toast.errorTitle,
+        description: content.toast.invalidEmail,
         variant: "destructive",
       });
       return;
@@ -79,55 +80,27 @@ export default function ContactSection() {
     contactMutation.mutate(formData);
   };
 
-  const contactInfo = [
-    {
-      icon: MapPin,
-      title: "Хаяг",
-      value: "Улаанбаатар, Монгол Улс",
-      color: "primary"
-    },
-    {
-      icon: Phone,
-      title: "Утас", 
-      value: "+976 ...",
-      color: "accent"
-    },
-    {
-      icon: Mail,
-      title: "Имэйл",
-      value: "info@mandakh.edu.mn",
-      color: "primary"
-    },
-    {
-      icon: Clock,
-      title: "Ажлын цаг",
-      value: "Даваа–Баасан 09:00–18:00", 
-      color: "accent"
-    }
-  ];
-
   return (
     <section id="contact" className="section-padding bg-background">
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Холбоо барих
+            {content.title}
           </h2>
           <p className="text-lg text-muted-foreground">
-            Асуулт байвал бидэнтэй холбогдоорой
+            {content.description}
           </p>
         </div>
 
         <div className="grid lg:grid-cols-2 gap-12">
-          {/* Contact Form */}
           <Card className="shadow-lg">
             <CardContent className="p-8">
               <h3 className="text-xl font-bold mb-6 text-card-foreground">
-                Мессеж илгээх
+                {content.formTitle}
               </h3>
               <form onSubmit={handleSubmit} className="space-y-6">
                 <div>
-                  <Label htmlFor="name">Нэр</Label>
+                  <Label htmlFor="name">{content.fields.name}</Label>
                   <Input
                     id="name"
                     name="name"
@@ -140,7 +113,7 @@ export default function ContactSection() {
                   />
                 </div>
                 <div>
-                  <Label htmlFor="phone">Утас</Label>
+                  <Label htmlFor="phone">{content.fields.phone}</Label>
                   <Input
                     id="phone"
                     name="phone"
@@ -152,7 +125,7 @@ export default function ContactSection() {
                   />
                 </div>
                 <div>
-                  <Label htmlFor="email">Имэйл</Label>
+                  <Label htmlFor="email">{content.fields.email}</Label>
                   <Input
                     id="email"
                     name="email"
@@ -165,7 +138,7 @@ export default function ContactSection() {
                   />
                 </div>
                 <div>
-                  <Label htmlFor="message">Зурвас</Label>
+                  <Label htmlFor="message">{content.fields.message}</Label>
                   <Textarea
                     id="message"
                     name="message"
@@ -177,57 +150,66 @@ export default function ContactSection() {
                     data-testid="textarea-message"
                   />
                 </div>
-                <Button 
-                  type="submit" 
+                <Button
+                  type="submit"
                   className="w-full"
                   disabled={contactMutation.isPending}
                   data-testid="button-submit-contact"
                 >
-                  {contactMutation.isPending ? "Илгээж байна..." : "Илгээх"}
+                  {contactMutation.isPending ? content.submit.loading : content.submit.idle}
                 </Button>
               </form>
             </CardContent>
           </Card>
 
-          {/* Contact Info & Map */}
           <div className="space-y-8">
             <Card className="shadow-lg">
               <CardContent className="p-8">
                 <h3 className="text-xl font-bold mb-6 text-card-foreground">
-                  Холбоо барих мэдээлэл
+                  {content.infoTitle}
                 </h3>
                 <div className="space-y-4">
-                  {contactInfo.map((info, index) => (
-                    <div key={index} className="flex items-center">
-                      <div className={`w-10 h-10 ${
-                        info.color === "primary" ? "bg-primary" : "bg-accent"
-                      } rounded-lg flex items-center justify-center mr-4`}>
-                        <info.icon className={`w-5 h-5 ${
-                          info.color === "primary" ? "text-primary-foreground" : "text-accent-foreground"
-                        }`} />
+                  {content.infoItems.map((info, index) => {
+                    const Icon = infoIcons[index];
+                    const color = index % 2 === 0 ? "primary" : "accent";
+
+                    return (
+                      <div key={`${info.title}-${index}`} className="flex items-center">
+                        <div
+                          className={`w-10 h-10 ${
+                            color === "primary" ? "bg-primary" : "bg-accent"
+                          } rounded-lg flex items-center justify-center mr-4`}
+                        >
+                          {Icon && (
+                            <Icon
+                              className={`w-5 h-5 ${
+                                color === "primary" ? "text-primary-foreground" : "text-accent-foreground"
+                              }`}
+                            />
+                          )}
+                        </div>
+                        <div>
+                          <p className="font-medium text-card-foreground">
+                            {info.title}
+                          </p>
+                          <p className="text-muted-foreground">
+                            {info.value}
+                          </p>
+                        </div>
                       </div>
-                      <div>
-                        <p className="font-medium text-card-foreground">
-                          {info.title}
-                        </p>
-                        <p className="text-muted-foreground">
-                          {info.value}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </CardContent>
             </Card>
 
-            {/* Google Maps Placeholder */}
             <Card className="shadow-lg">
               <CardContent className="p-4">
                 <div className="w-full h-64 bg-muted rounded-lg flex items-center justify-center">
                   <div className="text-center text-muted-foreground">
                     <MapPin className="w-12 h-12 mx-auto mb-2" />
-                    <p>Google Maps Placeholder</p>
-                    <p className="text-xs">Координат: Улаанбаатар хот</p>
+                    <p>{content.map.placeholder}</p>
+                    <p className="text-xs">{content.map.coordinates}</p>
                   </div>
                 </div>
               </CardContent>

--- a/client/src/components/faq-section.tsx
+++ b/client/src/components/faq-section.tsx
@@ -4,56 +4,34 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-
-const faqItems = [
-  {
-    question: "Сургалтын төлбөрийг хэрхэн төлөх вэ?",
-    answer: "Капитал банкны гүйлгээ, картаар болон цахимаар хуваан төлөх боломжтой."
-  },
-  {
-    question: "Тэтгэлэгт хөтөлбөр байдаг уу?",
-    answer: "Гүйцэтгэл, нийгмийн идэвх, тусгай шаардлагаар зарлагддаг."
-  },
-  {
-    question: "Дотуур байранд байрлах боломжтой юу?",
-    answer: "Тийм ээ, орчин үеийн дотуур байр байгаа бөгөөд хүсэлт гаргаж болно."
-  },
-  {
-    question: "Гадаад улсын оюутан элсэх боломжтой юу?", 
-    answer: "Тийм ээ, олон улсын оюутнуудыг хүлээн авдаг. Тусгай шаардлага хангах шаардлагатай."
-  },
-  {
-    question: "Ажилд ороход туслалцаа үзүүлдэг үү?",
-    answer: "Карьер хөгжлийн алба тусгайлан байгуулагдаж, ажлын байртай холбож өгдөг."
-  },
-  {
-    question: "Онлайн сургалт явуулдаг уу?",
-    answer: "Гибрид хэлбэрээр онлайн болон танхимын сургалтыг хослуулан явуулдаг."
-  }
-];
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
 export default function FaqSection() {
+  const { language } = useLanguage();
+  const content = translations.faq[language];
+
   return (
     <section id="faq" className="section-padding bg-secondary">
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Түгээмэл асуулт
+            {content.title}
           </h2>
           <p className="text-lg text-muted-foreground">
-            Их асуугддаг асуултууд болон хариултууд
+            {content.description}
           </p>
         </div>
 
         <div className="max-w-3xl mx-auto">
           <Accordion type="single" collapsible className="space-y-4">
-            {faqItems.map((item, index) => (
-              <AccordionItem 
-                key={index} 
+            {content.items.map((item, index) => (
+              <AccordionItem
+                key={item.question}
                 value={`item-${index}`}
                 className="bg-card rounded-xl shadow-lg px-6"
               >
-                <AccordionTrigger 
+                <AccordionTrigger
                   className="font-semibold text-card-foreground hover:text-primary transition-colors"
                   data-testid={`faq-question-${index}`}
                 >

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -1,19 +1,6 @@
 import { Facebook, Twitter, Instagram } from "lucide-react";
-
-const quickLinks = [
-  { href: "#about", label: "Бидний тухай" },
-  { href: "#programs", label: "Хөтөлбөрүүд" },
-  { href: "#admissions", label: "Элсэлт" },
-  { href: "#student-life", label: "Оюутны амьдрал" },
-  { href: "#contact", label: "Холбоо барих" }
-];
-
-const contactInfo = [
-  "+976 ...",
-  "info@mandakh.edu.mn", 
-  "Улаанбаатар, Монгол Улс",
-  "Даваа–Баасан 09:00–18:00"
-];
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
 const socialLinks = [
   { icon: Facebook, href: "#", label: "Facebook" },
@@ -22,6 +9,9 @@ const socialLinks = [
 ];
 
 export default function Footer() {
+  const { language } = useLanguage();
+  const content = translations.footer[language];
+
   const scrollToSection = (href: string) => {
     const element = document.querySelector(href);
     if (element) {
@@ -34,9 +24,9 @@ export default function Footer() {
       <div className="container mx-auto px-6 py-12">
         <div className="grid md:grid-cols-4 gap-8">
           <div className="md:col-span-2">
-            <h3 className="text-2xl font-bold mb-4">Мандах Их Сургууль</h3>
+            <h3 className="text-2xl font-bold mb-4">{content.title}</h3>
             <p className="text-primary-foreground/80 mb-6">
-              1992 оноос эхтэй уламжлалт сургалтын арга зүйг дижитал шилжилттэй хослуулж, хөдөлмөрийн зах зээлд бэлэн, ёс зүйтэй, бүтээлч мэргэжилтэн бэлтгэнэ.
+              {content.description}
             </p>
             <div className="flex space-x-4">
               {socialLinks.map((social) => (
@@ -54,9 +44,9 @@ export default function Footer() {
           </div>
 
           <div>
-            <h4 className="text-lg font-semibold mb-4">Хурдан линкүүд</h4>
+            <h4 className="text-lg font-semibold mb-4">{content.quickLinksTitle}</h4>
             <ul className="space-y-2 text-primary-foreground/80">
-              {quickLinks.map((link) => (
+              {content.quickLinks.map((link) => (
                 <li key={link.href}>
                   <button
                     onClick={() => scrollToSection(link.href)}
@@ -71,10 +61,10 @@ export default function Footer() {
           </div>
 
           <div>
-            <h4 className="text-lg font-semibold mb-4">Холбогдох</h4>
+            <h4 className="text-lg font-semibold mb-4">{content.contactTitle}</h4>
             <ul className="space-y-2 text-primary-foreground/80 text-sm">
-              {contactInfo.map((info, index) => (
-                <li key={index}>{info}</li>
+              {content.contactInfo.map((info, index) => (
+                <li key={`${info}-${index}`}>{info}</li>
               ))}
             </ul>
           </div>
@@ -82,7 +72,7 @@ export default function Footer() {
 
         <div className="border-t border-primary-foreground/20 mt-8 pt-8 text-center">
           <p className="text-primary-foreground/60 text-sm">
-            © 2025 Мандах Их Сургууль. Бүх эрх хуулиар хамгаалагдсан.
+            {content.copyright}
           </p>
         </div>
       </div>

--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -1,7 +1,12 @@
 import { ArrowDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
 export default function HeroSection() {
+  const { language } = useLanguage();
+  const content = translations.hero[language];
+
   const scrollToSection = (href: string) => {
     const element = document.querySelector(href);
     if (element) {
@@ -13,10 +18,10 @@ export default function HeroSection() {
     <section id="home" className="hero-gradient min-h-screen flex items-center">
       <div className="container mx-auto px-6 text-center text-white">
         <h1 className="text-5xl md:text-6xl font-bold mb-6 leading-tight">
-          Ирээдүйгээ Мандах-аас эхлүүлье.
+          {content.title}
         </h1>
         <p className="text-xl md:text-2xl mb-12 max-w-4xl mx-auto leading-relaxed">
-          Мандах Их Сургууль — санхүү, мэдээллийн технологи, бизнесийн чиглэлийн чанартай боловсролыг олон улсын стандарттай уялдуулан олгоно.
+          {content.description}
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Button
@@ -24,7 +29,7 @@ export default function HeroSection() {
             className="bg-accent text-accent-foreground px-8 py-4 rounded-lg font-semibold hover:bg-accent/90 transition-colors inline-flex items-center text-lg"
             data-testid="button-admissions"
           >
-            Элсэлтийн мэдээлэл
+            {content.primaryCta}
             <ArrowDown className="w-5 h-5 ml-2" />
           </Button>
           <Button
@@ -33,7 +38,7 @@ export default function HeroSection() {
             className="bg-transparent border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-primary transition-colors text-lg"
             data-testid="button-programs"
           >
-            Хөтөлбөрүүдийг үзэх
+            {content.secondaryCta}
           </Button>
         </div>
       </div>

--- a/client/src/components/language-switcher.tsx
+++ b/client/src/components/language-switcher.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { supportedLanguages, useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
+
+type LanguageSwitcherProps = {
+  className?: string;
+};
+
+export default function LanguageSwitcher({ className }: LanguageSwitcherProps) {
+  const { language, setLanguage } = useLanguage();
+  const content = translations.languageSwitcher[language];
+
+  return (
+    <div
+      className={cn("flex items-center gap-1", className)}
+      role="group"
+      aria-label={content.groupLabel}
+    >
+      {supportedLanguages.map((code) => (
+        <Button
+          key={code}
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setLanguage(code)}
+          aria-label={content.optionLabels[code]}
+          aria-pressed={language === code}
+          className={cn(
+            "h-8 px-3 text-xs font-semibold uppercase tracking-wide",
+            language === code
+              ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90"
+              : "border-input text-foreground hover:bg-accent hover:text-accent-foreground"
+          )}
+        >
+          {content.optionShort[code]}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -2,27 +2,20 @@ import { useState, useEffect } from "react";
 import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import mandakhLogo from "@/assets/mandakh-logo.svg";
-
-const navItems = [
-  { href: "#home", label: "Нүүр" },
-  { href: "#about", label: "Бидний тухай" },
-  { href: "#programs", label: "Хөтөлбөрүүд" },
-  { href: "#admissions", label: "Элсэлт" },
-  { href: "#student-life", label: "Оюутны амьдрал" },
-  { href: "#news", label: "Мэдээ" },
-  { href: "#partnerships", label: "Түншлэл" },
-  { href: "#faq", label: "Асуулт" },
-  { href: "#contact", label: "Холбоо барих" },
-];
+import LanguageSwitcher from "@/components/language-switcher";
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
 export default function Navigation() {
   const [isOpen, setIsOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("home");
+  const { language } = useLanguage();
+  const navContent = translations.navigation[language];
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = navItems.map(item => item.href.substring(1));
-      const current = sections.find(section => {
+      const sections = navContent.items.map((item) => item.href.substring(1));
+      const current = sections.find((section) => {
         const element = document.getElementById(section);
         if (element) {
           const rect = element.getBoundingClientRect();
@@ -37,7 +30,7 @@ export default function Navigation() {
 
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [language, navContent.items]);
 
   const scrollToSection = (href: string) => {
     const element = document.querySelector(href);
@@ -54,48 +47,52 @@ export default function Navigation() {
           <div className="flex items-center" data-testid="logo">
             <img
               src={mandakhLogo}
-              alt="Мандах Их Сургууль эмблем"
+              alt={navContent.logoAlt}
               className="h-12 w-auto"
             />
-            <span className="sr-only">Мандах Их Сургууль</span>
+            <span className="sr-only">{navContent.logoSr}</span>
           </div>
 
-          {/* Desktop Menu */}
-          <ul className="hidden md:flex space-x-8 text-sm font-medium">
-            {navItems.map((item) => (
-              <li key={item.href}>
-                <button
-                  onClick={() => scrollToSection(item.href)}
-                  className={`nav-link transition-colors hover:text-primary ${
-                    activeSection === item.href.substring(1)
-                      ? "text-primary"
-                      : "text-foreground"
-                  }`}
-                  data-testid={`nav-${item.href.substring(1)}`}
-                >
-                  {item.label}
-                </button>
-              </li>
-            ))}
-          </ul>
+          <div className="flex items-center gap-4">
+            <ul className="hidden md:flex space-x-8 text-sm font-medium">
+              {navContent.items.map((item) => (
+                <li key={item.href}>
+                  <button
+                    onClick={() => scrollToSection(item.href)}
+                    className={`nav-link transition-colors hover:text-primary ${
+                      activeSection === item.href.substring(1)
+                        ? "text-primary"
+                        : "text-foreground"
+                    }`}
+                    data-testid={`nav-${item.href.substring(1)}`}
+                  >
+                    {item.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
 
-          {/* Mobile Menu Button */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden"
-            onClick={() => setIsOpen(!isOpen)}
-            data-testid="mobile-menu-button"
-          >
-            {isOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
-          </Button>
+            <LanguageSwitcher className="hidden md:flex" />
+
+            <Button
+              variant="ghost"
+              size="icon"
+              className="md:hidden"
+              onClick={() => setIsOpen(!isOpen)}
+              data-testid="mobile-menu-button"
+              aria-expanded={isOpen}
+              aria-controls="mobile-navigation"
+            >
+              {isOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+            </Button>
+          </div>
         </div>
 
-        {/* Mobile Menu */}
         {isOpen && (
-          <div className="md:hidden mt-4 pb-4">
+          <div id="mobile-navigation" className="md:hidden mt-4 pb-4 space-y-4">
+            <LanguageSwitcher />
             <ul className="space-y-4 text-sm font-medium">
-              {navItems.map((item) => (
+              {navContent.items.map((item) => (
                 <li key={item.href}>
                   <button
                     onClick={() => scrollToSection(item.href)}

--- a/client/src/components/news-section.tsx
+++ b/client/src/components/news-section.tsx
@@ -1,56 +1,34 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-
-const newsItems = [
-  {
-    id: "research-conference",
-    date: "2025.02.15",
-    title: "Эрдэм шинжилгээний хурал 2025",
-    description: "Санхүү ба AI чиглэлийн илтгэлүүд, олон улсын судлаачдын оролцоотой...",
-    image: "https://images.unsplash.com/photo-1591115765373-5207764f72e7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
-    alt: "Эрдэм шинжилгээний хурлын танилцуулга"
-  },
-  {
-    id: "open-house",
-    date: "2025.02.20", 
-    title: "Нээлттэй хаалганы өдөр",
-    description: "Кампус танилцуулга, демо хичээл, зөвлөгөө авах боломжтой...",
-    image: "https://images.unsplash.com/photo-1541829070764-84a7d30dd3f3?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
-    alt: "Их сургуулийн нээлттэй хаалганы өдөр"
-  },
-  {
-    id: "graduation",
-    date: "2025.01.25",
-    title: "2024-2025 оны төгсөлтийн ёслол", 
-    description: "500 гаруй төгсөгч дипломоо гардуулж авлаа...",
-    image: "https://images.unsplash.com/photo-1523240795612-9a054b0db644?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
-    alt: "Төгсөлтийн ёслол"
-  }
-];
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
 export default function NewsSection() {
+  const { language } = useLanguage();
+  const content = translations.news[language];
+
   return (
     <section id="news" className="section-padding bg-background">
       <div className="container mx-auto px-6">
         <div className="flex justify-between items-center mb-16">
           <div>
             <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-              Мэдээ ба Үйл явдал
+              {content.title}
             </h2>
             <p className="text-lg text-muted-foreground">
-              Сүүлийн үеийн мэдээ, үйл явдлууд
+              {content.description}
             </p>
           </div>
-          <Button 
+          <Button
             className="hidden sm:block"
             data-testid="button-view-all-news"
           >
-            Бүгдийг харах
+            {content.viewAll}
           </Button>
         </div>
 
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {newsItems.map((item) => (
+          {content.items.map((item) => (
             <Card key={item.id} className="overflow-hidden card-hover">
               <div>
                 <img
@@ -70,11 +48,11 @@ export default function NewsSection() {
                 <p className="text-muted-foreground text-sm mb-4">
                   {item.description}
                 </p>
-                <button 
+                <button
                   className="text-primary font-medium text-sm hover:underline"
                   data-testid={`button-news-${item.id}`}
                 >
-                  Дэлгэрэнгүй унших
+                  {content.readMore}
                 </button>
               </CardContent>
             </Card>
@@ -83,7 +61,7 @@ export default function NewsSection() {
 
         <div className="text-center mt-8 sm:hidden">
           <Button data-testid="button-view-all-news-mobile">
-            Бүгдийг харах
+            {content.viewAll}
           </Button>
         </div>
       </div>

--- a/client/src/components/partnerships-section.tsx
+++ b/client/src/components/partnerships-section.tsx
@@ -1,21 +1,26 @@
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
+
 export default function PartnershipsSection() {
   const partnerPlaceholders = Array(6).fill(null);
+  const { language } = useLanguage();
+  const content = translations.partnerships[language];
 
   return (
     <section id="partnerships" className="section-padding bg-background">
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Түншлэл
+            {content.title}
           </h2>
           <p className="text-lg text-muted-foreground">
-            Олон улсын их сургуулиуд болон компаниудтай хамтран ажилладаг
+            {content.description}
           </p>
         </div>
 
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-8 items-center">
           {partnerPlaceholders.map((_, index) => (
-            <div 
+            <div
               key={index}
               className="bg-card p-6 rounded-xl shadow-lg flex items-center justify-center h-24 opacity-60 hover:opacity-100 transition-opacity"
             >

--- a/client/src/components/programs-section.tsx
+++ b/client/src/components/programs-section.tsx
@@ -2,103 +2,83 @@ import { DollarSign, Cpu, Lightbulb } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
-const programs = [
-  {
-    id: "finance",
-    title: "Санхүүгийн менежмент",
-    level: "Бакалавр",
-    duration: "4 жил • Өдрийн",
-    skills: [
-      "Санхүүгийн шинжилгээ",
-      "Тайлагнал боловсруулах", 
-      "Өгөгдөлд суурилсан шийдвэр"
-    ],
-    icon: DollarSign,
-    levelColor: "accent"
-  },
-  {
-    id: "information-systems",
-    title: "Мэдээллийн систем",
-    level: "Бакалавр", 
-    duration: "4 жил • Өдрийн/Оройн",
-    skills: [
-      "Веб хөгжүүлэлт",
-      "Өгөгдлийн сан",
-      "Автомажуулалт"
-    ],
-    icon: Cpu,
-    levelColor: "accent"
-  },
-  {
-    id: "business-management",
-    title: "Бизнесийн удирдлага",
-    level: "Магистр",
-    duration: "1.5 жил • Оройн", 
-    skills: [
-      "Стратеги боловсруулах",
-      "Манлайлал",
-      "Аналитик ур чадвар"
-    ],
-    icon: Lightbulb,
-    levelColor: "primary"
-  }
-];
+type ProgramMeta = {
+  icon: typeof DollarSign;
+  levelColor: "accent" | "primary";
+};
+
+const programMeta: Record<string, ProgramMeta> = {
+  finance: { icon: DollarSign, levelColor: "accent" },
+  "information-systems": { icon: Cpu, levelColor: "accent" },
+  "business-management": { icon: Lightbulb, levelColor: "primary" }
+};
 
 export default function ProgramsSection() {
+  const { language } = useLanguage();
+  const content = translations.programs[language];
+
   return (
     <section id="programs" className="section-padding bg-secondary">
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Хөтөлбөрүүд
+            {content.title}
           </h2>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Олон улсын стандарттай нийцсэн хөтөлбөрүүдийг сонгон суралцаарай
+            {content.description}
           </p>
         </div>
 
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {programs.map((program) => (
-            <Card key={program.id} className="card-hover">
-              <CardContent className="p-8">
-                <div className="flex items-center mb-4">
-                  <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center mr-4">
-                    <program.icon className="w-6 h-6 text-primary-foreground" />
+          {content.programs.map((program) => {
+            const meta = programMeta[program.id];
+            const Icon = meta?.icon ?? DollarSign;
+            const levelColor = meta?.levelColor ?? "accent";
+
+            return (
+              <Card key={program.id} className="card-hover">
+                <CardContent className="p-8">
+                  <div className="flex items-center mb-4">
+                    <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center mr-4">
+                      <Icon className="w-6 h-6 text-primary-foreground" />
+                    </div>
+                    <div>
+                      <Badge
+                        variant={levelColor === "accent" ? "secondary" : "default"}
+                        className={`text-xs font-semibold ${
+                          levelColor === "accent"
+                            ? "text-accent bg-accent/20"
+                            : "text-primary bg-primary/20"
+                        }`}
+                      >
+                        {program.level}
+                      </Badge>
+                    </div>
                   </div>
-                  <div>
-                    <Badge 
-                      variant={program.levelColor === "accent" ? "secondary" : "default"}
-                      className={`text-xs font-semibold ${
-                        program.levelColor === "accent" 
-                          ? "text-accent bg-accent/20" 
-                          : "text-primary bg-primary/20"
-                      }`}
-                    >
-                      {program.level}
-                    </Badge>
+                  <h3 className="text-xl font-bold mb-3 text-card-foreground">
+                    {program.title}
+                  </h3>
+                  <ul className="text-muted-foreground mb-4 space-y-1">
+                    {program.skills.map((skill, index) => (
+                      <li key={`${program.id}-skill-${index}`}>• {skill}</li>
+                    ))}
+                  </ul>
+                  <div className="flex justify-between items-center mb-4 text-sm text-muted-foreground">
+                    <span>{program.duration}</span>
                   </div>
-                </div>
-                <h3 className="text-xl font-bold mb-3 text-card-foreground">
-                  {program.title}
-                </h3>
-                <ul className="text-muted-foreground mb-4 space-y-1">
-                  {program.skills.map((skill, index) => (
-                    <li key={index}>• {skill}</li>
-                  ))}
-                </ul>
-                <div className="flex justify-between items-center mb-4 text-sm text-muted-foreground">
-                  <span>{program.duration}</span>
-                </div>
-                <Button 
-                  className="w-full"
-                  data-testid={`button-program-${program.id}`}
-                >
-                  Дэлгэрэнгүй
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
+                  <Button
+                    className="w-full"
+                    data-testid={`button-program-${program.id}`}
+                  >
+                    {content.buttonLabel}
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/client/src/components/student-life-section.tsx
+++ b/client/src/components/student-life-section.tsx
@@ -1,78 +1,58 @@
 import { Users, DollarSign, Building, Book, Zap, Trophy } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
-const facilities = [
-  {
-    title: "Клуб, клубууд",
-    description: "Спорт, урлаг, шинжлэх ухааны 20 гаруй клуб",
-    icon: Users,
-    color: "primary"
-  },
-  {
-    title: "Тэтгэлэг", 
-    description: "Гүйцэтгэл, нийгмийн байдлаар олгогддог тэтгэлэг",
-    icon: DollarSign,
-    color: "accent"
-  },
-  {
-    title: "Дотуур байр",
-    description: "Орчин үеийн дотуур байр, тав тухтай орчин", 
-    icon: Building,
-    color: "primary"
-  },
-  {
-    title: "Номын сан",
-    description: "100,000 гаруй ном, цахим нөөц, суралцах орчин",
-    icon: Book,
-    color: "accent"
-  },
-  {
-    title: "Инновацын лаборатори",
-    description: "Орчин үеийн тоног төхөөрөмж, практик сургалт",
-    icon: Zap,
-    color: "primary"
-  },
-  {
-    title: "Спортын заал", 
-    description: "Орчин үеийн спортын байгууламж, фитнесс төв",
-    icon: Trophy,
-    color: "accent"
-  }
-];
+const facilityIcons = [Users, DollarSign, Building, Book, Zap, Trophy];
+const facilityColors = ["primary", "accent", "primary", "accent", "primary", "accent"] as const;
 
 export default function StudentLifeSection() {
+  const { language } = useLanguage();
+  const content = translations.studentLife[language];
+
   return (
     <section id="student-life" className="section-padding bg-secondary">
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Оюутны амьдрал
+            {content.title}
           </h2>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Клуб, клубууд; тэтгэлэг; дотуур байр; номын сан; спортын заал; инновацын лаборатори—оюутны хөгжлийг бүх талаар дэмжинэ.
+            {content.description}
           </p>
         </div>
 
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {facilities.map((facility, index) => (
-            <Card key={index} className="card-hover text-center">
-              <CardContent className="p-6">
-                <div className={`w-16 h-16 ${
-                  facility.color === "primary" ? "bg-primary" : "bg-accent"
-                } rounded-full flex items-center justify-center mx-auto mb-4`}>
-                  <facility.icon className={`w-8 h-8 ${
-                    facility.color === "primary" ? "text-primary-foreground" : "text-accent-foreground"
-                  }`} />
-                </div>
-                <h3 className="text-lg font-semibold mb-2 text-card-foreground">
-                  {facility.title}
-                </h3>
-                <p className="text-muted-foreground text-sm">
-                  {facility.description}
-                </p>
-              </CardContent>
-            </Card>
-          ))}
+          {content.facilities.map((facility, index) => {
+            const Icon = facilityIcons[index];
+            const color = facilityColors[index] ?? "primary";
+
+            return (
+              <Card key={facility.title} className="card-hover text-center">
+                <CardContent className="p-6">
+                  <div
+                    className={`w-16 h-16 ${
+                      color === "primary" ? "bg-primary" : "bg-accent"
+                    } rounded-full flex items-center justify-center mx-auto mb-4`}
+                  >
+                    {Icon && (
+                      <Icon
+                        className={`w-8 h-8 ${
+                          color === "primary" ? "text-primary-foreground" : "text-accent-foreground"
+                        }`}
+                      />
+                    )}
+                  </div>
+                  <h3 className="text-lg font-semibold mb-2 text-card-foreground">
+                    {facility.title}
+                  </h3>
+                  <p className="text-muted-foreground text-sm">
+                    {facility.description}
+                  </p>
+                </CardContent>
+              </Card>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/client/src/components/testimonials-section.tsx
+++ b/client/src/components/testimonials-section.tsx
@@ -1,50 +1,35 @@
 import { Card, CardContent } from "@/components/ui/card";
-
-const testimonials = [
-  {
-    name: "Б.Анударь",
-    program: "Санхүү 2023",
-    quote: "Ажилд гарах бэлтгэлтэй болгосон практик курсууд надад их тус болсон.",
-    initials: "Б.А",
-    color: "primary"
-  },
-  {
-    name: "Т.Баярмаа", 
-    program: "Мэдээллийн систем 2022",
-    quote: "Орчин үеийн технологийн мэдлэг, практик туршлага олж авсан.",
-    initials: "Т.Б",
-    color: "accent"
-  },
-  {
-    name: "Д.Ганбат",
-    program: "MBA 2021", 
-    quote: "Удирдлагын чадварыг хөгжүүлэх боломж олдсон нь миний карьерт чухал үүрэг гүйцэтгэсэн.",
-    initials: "Д.Г",
-    color: "primary"
-  }
-];
+import { useLanguage } from "@/lib/language-context";
+import { translations } from "@/lib/translations";
 
 export default function TestimonialsSection() {
+  const { language } = useLanguage();
+  const content = translations.testimonials[language];
+
   return (
     <section className="section-padding bg-secondary">
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
-            Төгсөгчдийн сэтгэгдэл
+            {content.title}
           </h2>
           <p className="text-lg text-muted-foreground">
-            Манай төгсөгчид хэлэх үг
+            {content.description}
           </p>
         </div>
 
         <div className="grid md:grid-cols-3 gap-8">
-          {testimonials.map((testimonial, index) => (
-            <Card key={index}>
+          {content.testimonials.map((testimonial, index) => (
+            <Card key={`${testimonial.name}-${index}`}>
               <CardContent className="p-8">
                 <div className="flex items-center mb-4">
-                  <div className={`w-12 h-12 ${
-                    testimonial.color === "primary" ? "bg-primary text-primary-foreground" : "bg-accent text-accent-foreground"
-                  } rounded-full flex items-center justify-center font-bold`}>
+                  <div
+                    className={`w-12 h-12 ${
+                      testimonial.color === "primary"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-accent text-accent-foreground"
+                    } rounded-full flex items-center justify-center font-bold`}
+                  >
                     {testimonial.initials}
                   </div>
                   <div className="ml-4">

--- a/client/src/lib/language-context.tsx
+++ b/client/src/lib/language-context.tsx
@@ -1,0 +1,55 @@
+import { type ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+export const supportedLanguages = ["mn", "en"] as const;
+export type Language = (typeof supportedLanguages)[number];
+
+const DEFAULT_LANGUAGE: Language = "mn";
+const STORAGE_KEY = "mandakh-language";
+
+type LanguageContextValue = {
+  language: Language;
+  setLanguage: (language: Language) => void;
+};
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<Language>(() => {
+    if (typeof window === "undefined") {
+      return DEFAULT_LANGUAGE;
+    }
+
+    const storedLanguage = window.localStorage.getItem(STORAGE_KEY);
+    if (storedLanguage === "mn" || storedLanguage === "en") {
+      return storedLanguage;
+    }
+
+    return DEFAULT_LANGUAGE;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, language);
+  }, [language]);
+
+  const setLanguage = useCallback((newLanguage: Language) => {
+    setLanguageState(newLanguage);
+  }, []);
+
+  const value = useMemo(() => ({ language, setLanguage }), [language, setLanguage]);
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+
+  return context;
+}

--- a/client/src/lib/translations.ts
+++ b/client/src/lib/translations.ts
@@ -1,0 +1,737 @@
+import type { Language } from "./language-context";
+
+type LanguageRecord<T> = Record<Language, T>;
+
+type NavigationContent = {
+  items: { href: string; label: string }[];
+  logoAlt: string;
+  logoSr: string;
+};
+
+type HeroContent = {
+  title: string;
+  description: string;
+  primaryCta: string;
+  secondaryCta: string;
+};
+
+type AboutContent = {
+  title: string;
+  description: string;
+  stats: string[];
+  imageAlt: string;
+  cards: { title: string; description: string }[];
+};
+
+type Program = {
+  id: string;
+  title: string;
+  level: string;
+  duration: string;
+  skills: string[];
+};
+
+type ProgramsContent = {
+  title: string;
+  description: string;
+  buttonLabel: string;
+  programs: Program[];
+};
+
+type AdmissionsStep = {
+  step: number;
+  title: string;
+  description: string;
+};
+
+type AdmissionsContent = {
+  title: string;
+  description: string;
+  steps: AdmissionsStep[];
+  requirementsTitle: string;
+  requirementsDescription: string;
+  downloadButton: string;
+  registerButton: string;
+};
+
+type StudentLifeContent = {
+  title: string;
+  description: string;
+  facilities: { title: string; description: string }[];
+};
+
+type NewsItem = {
+  id: string;
+  date: string;
+  title: string;
+  description: string;
+  image: string;
+  alt: string;
+};
+
+type NewsContent = {
+  title: string;
+  description: string;
+  viewAll: string;
+  readMore: string;
+  items: NewsItem[];
+};
+
+type TestimonialsContent = {
+  title: string;
+  description: string;
+  testimonials: { name: string; program: string; quote: string; initials: string; color: "primary" | "accent" }[];
+};
+
+type PartnershipsContent = {
+  title: string;
+  description: string;
+};
+
+type FaqContent = {
+  title: string;
+  description: string;
+  items: { question: string; answer: string }[];
+};
+
+type ContactContent = {
+  title: string;
+  description: string;
+  formTitle: string;
+  fields: {
+    name: string;
+    phone: string;
+    email: string;
+    message: string;
+  };
+  submit: {
+    idle: string;
+    loading: string;
+  };
+  infoTitle: string;
+  infoItems: { title: string; value: string }[];
+  map: {
+    placeholder: string;
+    coordinates: string;
+  };
+  toast: {
+    successTitle: string;
+    successDescription: string;
+    errorTitle: string;
+    requiredFields: string;
+    invalidEmail: string;
+    submitError: string;
+  };
+};
+
+type FooterContent = {
+  title: string;
+  description: string;
+  quickLinksTitle: string;
+  quickLinks: { href: string; label: string }[];
+  contactTitle: string;
+  contactInfo: string[];
+  copyright: string;
+};
+
+type LanguageSwitcherContent = {
+  groupLabel: string;
+  optionLabels: Record<Language, string>;
+  optionShort: Record<Language, string>;
+};
+
+type AppTranslations = {
+  languageSwitcher: LanguageRecord<LanguageSwitcherContent>;
+  navigation: LanguageRecord<NavigationContent>;
+  hero: LanguageRecord<HeroContent>;
+  about: LanguageRecord<AboutContent>;
+  programs: LanguageRecord<ProgramsContent>;
+  admissions: LanguageRecord<AdmissionsContent>;
+  studentLife: LanguageRecord<StudentLifeContent>;
+  news: LanguageRecord<NewsContent>;
+  testimonials: LanguageRecord<TestimonialsContent>;
+  partnerships: LanguageRecord<PartnershipsContent>;
+  faq: LanguageRecord<FaqContent>;
+  contact: LanguageRecord<ContactContent>;
+  footer: LanguageRecord<FooterContent>;
+};
+
+export const translations: AppTranslations = {
+  languageSwitcher: {
+    mn: {
+      groupLabel: "Хэл сонгох",
+      optionLabels: {
+        mn: "Монгол хэл",
+        en: "Англи хэл"
+      },
+      optionShort: {
+        mn: "MN",
+        en: "EN"
+      }
+    },
+    en: {
+      groupLabel: "Select language",
+      optionLabels: {
+        mn: "Mongolian",
+        en: "English"
+      },
+      optionShort: {
+        mn: "MN",
+        en: "EN"
+      }
+    }
+  },
+  navigation: {
+    mn: {
+      items: [
+        { href: "#home", label: "Нүүр" },
+        { href: "#about", label: "Бидний тухай" },
+        { href: "#programs", label: "Хөтөлбөрүүд" },
+        { href: "#admissions", label: "Элсэлт" },
+        { href: "#student-life", label: "Оюутны амьдрал" },
+        { href: "#news", label: "Мэдээ" },
+        { href: "#partnerships", label: "Түншлэл" },
+        { href: "#faq", label: "Асуулт" },
+        { href: "#contact", label: "Холбоо барих" }
+      ],
+      logoAlt: "Мандах Их Сургууль эмблем",
+      logoSr: "Мандах Их Сургууль"
+    },
+    en: {
+      items: [
+        { href: "#home", label: "Home" },
+        { href: "#about", label: "About" },
+        { href: "#programs", label: "Programs" },
+        { href: "#admissions", label: "Admissions" },
+        { href: "#student-life", label: "Student Life" },
+        { href: "#news", label: "News" },
+        { href: "#partnerships", label: "Partnerships" },
+        { href: "#faq", label: "FAQ" },
+        { href: "#contact", label: "Contact" }
+      ],
+      logoAlt: "Mandakh University emblem",
+      logoSr: "Mandakh University"
+    }
+  },
+  hero: {
+    mn: {
+      title: "Ирээдүйгээ Мандах-аас эхлүүлье.",
+      description:
+        "Мандах Их Сургууль — санхүү, мэдээллийн технологи, бизнесийн чиглэлийн чанартай боловсролыг олон улсын стандарттай уялдуулан олгоно.",
+      primaryCta: "Элсэлтийн мэдээлэл",
+      secondaryCta: "Хөтөлбөрүүдийг үзэх"
+    },
+    en: {
+      title: "Start your future at Mandakh.",
+      description:
+        "Mandakh University delivers high-quality education in finance, information technology, and business aligned with international standards.",
+      primaryCta: "Admissions information",
+      secondaryCta: "Explore programs"
+    }
+  },
+  about: {
+    mn: {
+      title: "Бидний тухай",
+      description:
+        "1992 оноос эхтэй уламжлалт сургалтын арга зүйг дижитал шилжилттэй хослуулж, хөдөлмөрийн зах зээлд бэлэн, ёс зүйтэй, бүтээлч мэргэжилтэн бэлтгэнэ.",
+      stats: ["30+ жилийн туршлага", "5000+ төгсөгч"],
+      imageAlt: "Их сургуулийн кампус",
+      cards: [
+        {
+          title: "Эрхэм зорилго",
+          description: "Чанартай боловсролоор нийгмийн хөгжилд хувь нэмэр оруулах."
+        },
+        {
+          title: "Алсын хараа",
+          description: "Судалгаа, инновацаар тэргүүлсэн их сургууль."
+        },
+        {
+          title: "Үнэт зүйлс",
+          description: "Оюунлаг байдал • Шударга ёс • Хамтын хөгжил."
+        }
+      ]
+    },
+    en: {
+      title: "About us",
+      description:
+        "Since 1992 we have blended time-tested teaching with digital transformation to prepare ethical, creative professionals who are ready for the job market.",
+      stats: ["30+ years of experience", "5000+ graduates"],
+      imageAlt: "University campus",
+      cards: [
+        {
+          title: "Mission",
+          description: "Contribute to society through high-quality education."
+        },
+        {
+          title: "Vision",
+          description: "A university leading through research and innovation."
+        },
+        {
+          title: "Values",
+          description: "Intellectual curiosity • Integrity • Collective growth."
+        }
+      ]
+    }
+  },
+  programs: {
+    mn: {
+      title: "Хөтөлбөрүүд",
+      description: "Олон улсын стандарттай нийцсэн хөтөлбөрүүдийг сонгон суралцаарай",
+      buttonLabel: "Дэлгэрэнгүй",
+      programs: [
+        {
+          id: "finance",
+          title: "Санхүүгийн менежмент",
+          level: "Бакалавр",
+          duration: "4 жил • Өдрийн",
+          skills: ["Санхүүгийн шинжилгээ", "Тайлагнал боловсруулах", "Өгөгдөлд суурилсан шийдвэр"]
+        },
+        {
+          id: "information-systems",
+          title: "Мэдээллийн систем",
+          level: "Бакалавр",
+          duration: "4 жил • Өдрийн/Оройн",
+          skills: ["Веб хөгжүүлэлт", "Өгөгдлийн сан", "Автомажуулалт"]
+        },
+        {
+          id: "business-management",
+          title: "Бизнесийн удирдлага",
+          level: "Магистр",
+          duration: "1.5 жил • Оройн",
+          skills: ["Стратеги боловсруулах", "Манлайлал", "Аналитик ур чадвар"]
+        }
+      ]
+    },
+    en: {
+      title: "Academic programs",
+      description: "Choose from programs aligned with international standards.",
+      buttonLabel: "Learn more",
+      programs: [
+        {
+          id: "finance",
+          title: "Financial Management",
+          level: "Bachelor",
+          duration: "4 years • Daytime",
+          skills: ["Financial analysis", "Reporting preparation", "Data-driven decisions"]
+        },
+        {
+          id: "information-systems",
+          title: "Information Systems",
+          level: "Bachelor",
+          duration: "4 years • Daytime/Evening",
+          skills: ["Web development", "Databases", "Automation"]
+        },
+        {
+          id: "business-management",
+          title: "Business Administration",
+          level: "Master",
+          duration: "1.5 years • Evening",
+          skills: ["Strategy development", "Leadership", "Analytical skills"]
+        }
+      ]
+    }
+  },
+  admissions: {
+    mn: {
+      title: "Элсэлт",
+      description: "Элсэлтийн үйл явц, шаардлага, хугацаа",
+      steps: [
+        {
+          step: 1,
+          title: "Бүртгүүлэх",
+          description: "Онлайн бүртгэл хийх, хувийн мэдээлэл оруулах"
+        },
+        {
+          step: 2,
+          title: "Бичиг баримт",
+          description: "Шаардлагатай баримтуудыг бүрдүүлэх"
+        },
+        {
+          step: 3,
+          title: "Шалгалт/Ярилцлага",
+          description: "Элсэлтийн шалгалт болон ярилцлага"
+        },
+        {
+          step: 4,
+          title: "Элсэлт баталгаажуулах",
+          description: "Элсэн орох эрхийг баталгаажуулах"
+        }
+      ],
+      requirementsTitle: "Шаардлагатай баримтууд",
+      requirementsDescription:
+        "Онлайн бүртгэл нээлттэй. Бүрдүүлэх материал: иргэний үнэмлэх, цээж зураг, ЭЕШ оноо/дунд сургуулийн голч дүн, цахим төлбөрийн баримт.",
+      downloadButton: "Элсэлтийн журам (PDF)",
+      registerButton: "Онлайн бүртгүүлэх"
+    },
+    en: {
+      title: "Admissions",
+      description: "Process, requirements, and deadlines",
+      steps: [
+        {
+          step: 1,
+          title: "Register",
+          description: "Complete online registration and submit personal details"
+        },
+        {
+          step: 2,
+          title: "Documents",
+          description: "Prepare the required documents"
+        },
+        {
+          step: 3,
+          title: "Exam/Interview",
+          description: "Admissions exam and interview"
+        },
+        {
+          step: 4,
+          title: "Confirm enrollment",
+          description: "Confirm your offer and enrollment"
+        }
+      ],
+      requirementsTitle: "Required documents",
+      requirementsDescription:
+        "Online registration is open. Prepare these materials: national ID, ID photo, entrance exam scores or high school GPA, and digital payment receipt.",
+      downloadButton: "Admissions guidelines (PDF)",
+      registerButton: "Register online"
+    }
+  },
+  studentLife: {
+    mn: {
+      title: "Оюутны амьдрал",
+      description:
+        "Клуб, клубууд; тэтгэлэг; дотуур байр; номын сан; спортын заал; инновацын лаборатори—оюутны хөгжлийг бүх талаар дэмжинэ.",
+      facilities: [
+        { title: "Клуб, клубууд", description: "Спорт, урлаг, шинжлэх ухааны 20 гаруй клуб" },
+        { title: "Тэтгэлэг", description: "Гүйцэтгэл, нийгмийн байдлаар олгогддог тэтгэлэг" },
+        { title: "Дотуур байр", description: "Орчин үеийн дотуур байр, тав тухтай орчин" },
+        { title: "Номын сан", description: "100,000 гаруй ном, цахим нөөц, суралцах орчин" },
+        { title: "Инновацын лаборатори", description: "Орчин үеийн тоног төхөөрөмж, практик сургалт" },
+        { title: "Спортын заал", description: "Орчин үеийн спортын байгууламж, фитнесс төв" }
+      ]
+    },
+    en: {
+      title: "Student life",
+      description:
+        "Clubs, scholarships, dormitories, library, sports hall, and an innovation lab—all supporting student development from every angle.",
+      facilities: [
+        { title: "Clubs & societies", description: "Over 20 clubs for sports, arts, and science" },
+        { title: "Scholarships", description: "Performance- and need-based scholarships" },
+        { title: "Dormitory", description: "Modern dormitory with a comfortable environment" },
+        { title: "Library", description: "100,000+ books, digital resources, and study areas" },
+        { title: "Innovation lab", description: "Hands-on training with modern equipment" },
+        { title: "Sports hall", description: "Modern sports facilities and fitness center" }
+      ]
+    }
+  },
+  news: {
+    mn: {
+      title: "Мэдээ ба Үйл явдал",
+      description: "Сүүлийн үеийн мэдээ, үйл явдлууд",
+      viewAll: "Бүгдийг харах",
+      readMore: "Дэлгэрэнгүй унших",
+      items: [
+        {
+          id: "research-conference",
+          date: "2025.02.15",
+          title: "Эрдэм шинжилгээний хурал 2025",
+          description: "Санхүү ба AI чиглэлийн илтгэлүүд, олон улсын судлаачдын оролцоотой...",
+          image: "https://images.unsplash.com/photo-1591115765373-5207764f72e7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
+          alt: "Эрдэм шинжилгээний хурлын танилцуулга"
+        },
+        {
+          id: "open-house",
+          date: "2025.02.20",
+          title: "Нээлттэй хаалганы өдөр",
+          description: "Кампус танилцуулга, демо хичээл, зөвлөгөө авах боломжтой...",
+          image: "https://images.unsplash.com/photo-1541829070764-84a7d30dd3f3?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
+          alt: "Их сургуулийн нээлттэй хаалганы өдөр"
+        },
+        {
+          id: "graduation",
+          date: "2025.01.25",
+          title: "2024-2025 оны төгсөлтийн ёслол",
+          description: "500 гаруй төгсөгч дипломоо гардуулж авлаа...",
+          image: "https://images.unsplash.com/photo-1523240795612-9a054b0db644?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
+          alt: "Төгсөлтийн ёслол"
+        }
+      ]
+    },
+    en: {
+      title: "News & events",
+      description: "Latest updates and happenings",
+      viewAll: "View all",
+      readMore: "Read more",
+      items: [
+        {
+          id: "research-conference",
+          date: "2025.02.15",
+          title: "Research Conference 2025",
+          description: "Finance and AI presentations featuring international researchers...",
+          image: "https://images.unsplash.com/photo-1591115765373-5207764f72e7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
+          alt: "Research conference presentation"
+        },
+        {
+          id: "open-house",
+          date: "2025.02.20",
+          title: "Open House Day",
+          description: "Campus tours, demo classes, and advising opportunities...",
+          image: "https://images.unsplash.com/photo-1541829070764-84a7d30dd3f3?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
+          alt: "University open house day"
+        },
+        {
+          id: "graduation",
+          date: "2025.01.25",
+          title: "2024–2025 Commencement Ceremony",
+          description: "Over 500 graduates proudly received their diplomas...",
+          image: "https://images.unsplash.com/photo-1523240795612-9a054b0db644?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&h=400",
+          alt: "Graduation ceremony"
+        }
+      ]
+    }
+  },
+  testimonials: {
+    mn: {
+      title: "Төгсөгчдийн сэтгэгдэл",
+      description: "Манай төгсөгчид хэлэх үг",
+      testimonials: [
+        {
+          name: "Б.Анударь",
+          program: "Санхүү 2023",
+          quote: "Ажилд гарах бэлтгэлтэй болгосон практик курсууд надад их тус болсон.",
+          initials: "Б.А",
+          color: "primary"
+        },
+        {
+          name: "Т.Баярмаа",
+          program: "Мэдээллийн систем 2022",
+          quote: "Орчин үеийн технологийн мэдлэг, практик туршлага олж авсан.",
+          initials: "Т.Б",
+          color: "accent"
+        },
+        {
+          name: "Д.Ганбат",
+          program: "MBA 2021",
+          quote: "Удирдлагын чадварыг хөгжүүлэх боломж олдсон нь миний карьерт чухал үүрэг гүйцэтгэсэн.",
+          initials: "Д.Г",
+          color: "primary"
+        }
+      ]
+    },
+    en: {
+      title: "Alumni stories",
+      description: "What our graduates say",
+      testimonials: [
+        {
+          name: "B. Anudari",
+          program: "Finance, Class of 2023",
+          quote: "The practical courses prepared me well for the workforce.",
+          initials: "Б.А",
+          color: "primary"
+        },
+        {
+          name: "T. Bayarmaa",
+          program: "Information Systems, Class of 2022",
+          quote: "I gained up-to-date tech knowledge and hands-on experience.",
+          initials: "Т.Б",
+          color: "accent"
+        },
+        {
+          name: "D. Ganbat",
+          program: "MBA, Class of 2021",
+          quote: "Opportunities to grow leadership skills made a big difference in my career.",
+          initials: "Д.Г",
+          color: "primary"
+        }
+      ]
+    }
+  },
+  partnerships: {
+    mn: {
+      title: "Түншлэл",
+      description: "Олон улсын их сургуулиуд болон компаниудтай хамтран ажилладаг"
+    },
+    en: {
+      title: "Partnerships",
+      description: "We collaborate with international universities and companies"
+    }
+  },
+  faq: {
+    mn: {
+      title: "Түгээмэл асуулт",
+      description: "Их асуугддаг асуултууд болон хариултууд",
+      items: [
+        {
+          question: "Сургалтын төлбөрийг хэрхэн төлөх вэ?",
+          answer: "Капитал банкны гүйлгээ, картаар болон цахимаар хуваан төлөх боломжтой."
+        },
+        {
+          question: "Тэтгэлэгт хөтөлбөр байдаг уу?",
+          answer: "Гүйцэтгэл, нийгмийн идэвх, тусгай шаардлагаар зарлагддаг."
+        },
+        {
+          question: "Дотуур байранд байрлах боломжтой юу?",
+          answer: "Тийм ээ, орчин үеийн дотуур байр байгаа бөгөөд хүсэлт гаргаж болно."
+        },
+        {
+          question: "Гадаад улсын оюутан элсэх боломжтой юу?",
+          answer:
+            "Тийм ээ, олон улсын оюутнуудыг хүлээн авдаг. Тусгай шаардлага хангах шаардлагатай."
+        },
+        {
+          question: "Ажилд ороход туслалцаа үзүүлдэг үү?",
+          answer: "Карьер хөгжлийн алба тусгайлан байгуулагдаж, ажлын байртай холбож өгдөг."
+        },
+        {
+          question: "Онлайн сургалт явуулдаг уу?",
+          answer: "Гибрид хэлбэрээр онлайн болон танхимын сургалтыг хослуулан явуулдаг."
+        }
+      ]
+    },
+    en: {
+      title: "Frequently asked questions",
+      description: "Answers to the questions we hear most often",
+      items: [
+        {
+          question: "How can I pay tuition fees?",
+          answer: "Pay via Capital Bank transfer, card payment, or online installments."
+        },
+        {
+          question: "Are scholarships available?",
+          answer: "Yes, based on performance, community involvement, and special criteria."
+        },
+        {
+          question: "Is on-campus housing available?",
+          answer: "Yes, we offer a modern dormitory and you can apply for a room."
+        },
+        {
+          question: "Can international students enroll?",
+          answer: "Absolutely, we welcome international students who meet the requirements."
+        },
+        {
+          question: "Do you help students find jobs?",
+          answer: "Our career center connects students with employment opportunities."
+        },
+        {
+          question: "Do you offer online classes?",
+          answer: "We provide hybrid learning that combines online and in-person classes."
+        }
+      ]
+    }
+  },
+  contact: {
+    mn: {
+      title: "Холбоо барих",
+      description: "Асуулт байвал бидэнтэй холбогдоорой",
+      formTitle: "Мессеж илгээх",
+      fields: {
+        name: "Нэр",
+        phone: "Утас",
+        email: "Имэйл",
+        message: "Зурвас"
+      },
+      submit: {
+        idle: "Илгээх",
+        loading: "Илгээж байна..."
+      },
+      infoTitle: "Холбоо барих мэдээлэл",
+      infoItems: [
+        { title: "Хаяг", value: "Улаанбаатар, Монгол Улс" },
+        { title: "Утас", value: "+976 ..." },
+        { title: "Имэйл", value: "info@mandakh.edu.mn" },
+        { title: "Ажлын цаг", value: "Даваа–Баасан 09:00–18:00" }
+      ],
+      map: {
+        placeholder: "Google Maps Placeholder",
+        coordinates: "Координат: Улаанбаатар хот"
+      },
+      toast: {
+        successTitle: "Амжилттай",
+        successDescription: "Таны мессеж амжилттай илгээгдлээ!",
+        errorTitle: "Алдаа",
+        requiredFields: "Бүх шаардлагатай талбарыг бөглөнө үү",
+        invalidEmail: "Зөв имэйл хаяг оруулна уу",
+        submitError: "Мессеж илгээхэд алдаа гарлаа"
+      }
+    },
+    en: {
+      title: "Contact us",
+      description: "Reach out with any questions",
+      formTitle: "Send a message",
+      fields: {
+        name: "Name",
+        phone: "Phone",
+        email: "Email",
+        message: "Message"
+      },
+      submit: {
+        idle: "Send",
+        loading: "Sending..."
+      },
+      infoTitle: "Contact information",
+      infoItems: [
+        { title: "Address", value: "Ulaanbaatar, Mongolia" },
+        { title: "Phone", value: "+976 ..." },
+        { title: "Email", value: "info@mandakh.edu.mn" },
+        { title: "Office hours", value: "Monday–Friday 09:00–18:00" }
+      ],
+      map: {
+        placeholder: "Google Maps placeholder",
+        coordinates: "Coordinates: Ulaanbaatar city"
+      },
+      toast: {
+        successTitle: "Success",
+        successDescription: "Your message was sent successfully!",
+        errorTitle: "Error",
+        requiredFields: "Please fill in all required fields",
+        invalidEmail: "Please enter a valid email address",
+        submitError: "Something went wrong while sending your message"
+      }
+    }
+  },
+  footer: {
+    mn: {
+      title: "Мандах Их Сургууль",
+      description:
+        "1992 оноос эхтэй уламжлалт сургалтын арга зүйг дижитал шилжилттэй хослуулж, хөдөлмөрийн зах зээлд бэлэн, ёс зүйтэй, бүтээлч мэргэжилтэн бэлтгэнэ.",
+      quickLinksTitle: "Хурдан линкүүд",
+      quickLinks: [
+        { href: "#about", label: "Бидний тухай" },
+        { href: "#programs", label: "Хөтөлбөрүүд" },
+        { href: "#admissions", label: "Элсэлт" },
+        { href: "#student-life", label: "Оюутны амьдрал" },
+        { href: "#contact", label: "Холбоо барих" }
+      ],
+      contactTitle: "Холбогдох",
+      contactInfo: [
+        "+976 ...",
+        "info@mandakh.edu.mn",
+        "Улаанбаатар, Монгол Улс",
+        "Даваа–Баасан 09:00–18:00"
+      ],
+      copyright: "© 2025 Мандах Их Сургууль. Бүх эрх хуулиар хамгаалагдсан."
+    },
+    en: {
+      title: "Mandakh University",
+      description:
+        "Since 1992 we have blended tradition and digital transformation to graduate ethical, creative professionals who are ready for the job market.",
+      quickLinksTitle: "Quick links",
+      quickLinks: [
+        { href: "#about", label: "About" },
+        { href: "#programs", label: "Programs" },
+        { href: "#admissions", label: "Admissions" },
+        { href: "#student-life", label: "Student Life" },
+        { href: "#contact", label: "Contact" }
+      ],
+      contactTitle: "Get in touch",
+      contactInfo: [
+        "+976 ...",
+        "info@mandakh.edu.mn",
+        "Ulaanbaatar, Mongolia",
+        "Monday–Friday 09:00–18:00"
+      ],
+      copyright: "© 2025 Mandakh University. All rights reserved."
+    }
+  }
+};
+
+export type SectionTranslations = typeof translations;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { LanguageProvider } from "@/lib/language-context";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <LanguageProvider>
+    <App />
+  </LanguageProvider>
+);


### PR DESCRIPTION
## Summary
- add a language provider, translation catalog, and switcher to support English and Mongolian
- update navigation and all marketing sections to pull copy from the translation data so content swaps languages

## Testing
- npm run check *(fails: existing express-session typings for req.session)*

------
https://chatgpt.com/codex/tasks/task_e_68d05ceeff3483308fb657563ad9d12c