### PR TITLE
Handle chatbot errors with assistant message

### DIFF
--- a/client/src/components/chatbot.tsx
+++ b/client/src/components/chatbot.tsx
@@ -132,8 +132,21 @@ export default function ChatbotWidget() {
       setMessages(finalMessages);
     } catch (error) {
       console.error("Chatbot error", error);
-      setMessages(messagesRef.current);
-      setError("Түр алдаа гарлаа. Дараа дахин оролдоно уу.");
+      const errorText =
+        error instanceof Error && error.message.trim().length > 0
+          ? error.message
+          : "Түр алдаа гарлаа. Дараа дахин оролдоно уу.";
+
+      const assistantErrorMessage: ChatMessage = {
+        id: `assistant-error-${Date.now()}`,
+        role: "assistant",
+        content: errorText
+      };
+
+      const finalMessages = [...messagesRef.current, assistantErrorMessage];
+      messagesRef.current = finalMessages;
+      setMessages(finalMessages);
+      setError(errorText);
     } finally {
       setIsLoading(false);
       window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- surface chatbot error responses to the user by turning them into assistant messages
- fall back to a friendly default message when no specific error text is available

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4119d178883309bd8200de61e824d